### PR TITLE
Add support for empty, gzip-encoded, responses

### DIFF
--- a/src/SharpGIS.GZipWebClient/GZipDeflateStream.cs
+++ b/src/SharpGIS.GZipWebClient/GZipDeflateStream.cs
@@ -28,7 +28,15 @@ namespace SharpGIS
 
 		private void ProcessStream()
 		{
-			if ((0x1f != _deflatedStream.ReadByte()) || // ID1
+			int firstByte = _deflatedStream.ReadByte();
+
+			if (firstByte == -1)
+			{
+				_inflatedStream = new MemoryStream();
+				return;
+			}
+
+			if ((0x1f != firstByte) || // ID1
 			    (0x8b != _deflatedStream.ReadByte()) || // ID2
 			    (8 != _deflatedStream.ReadByte())) // CM (8 == deflate)
 			{


### PR DESCRIPTION
I noticed that some servers add Content-Encoding: encoding to a 304 response (which has no content). In this Scenario GZipWebClient detects it as a compressed response that has an invalid zip header.

This pull request adds detection for this scenario.
