### PR TITLE
User Agent gets overwritten so manually set to IE 10.0

### DIFF
--- a/src/SharpGIS.GZipWebClient/GZipHttpWebRequest.cs
+++ b/src/SharpGIS.GZipWebClient/GZipHttpWebRequest.cs
@@ -23,6 +23,7 @@ namespace SharpGIS
 		{
 			_internalWebRequest = System.Net.WebRequest.CreateHttp(uri);
 			Headers[HttpRequestHeader.AcceptEncoding] = "gzip";
+			Headers[HttpRequestHeader.UserAgent] = "Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch";
 		}
 
 		public override IAsyncResult BeginGetRequestStream(AsyncCallback callback, object state)


### PR DESCRIPTION
After creating the HttpWebRequest as 

--- C# code ---

var request = HttpWebRequest.Create(destinationUri) as HttpWebRequest;
request.Headers["User-Agent"] = "Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch"

--- End Code --

The User-Agent doesn't get populated as shown. (I checked using Wireshark and Fiddler).

I've put the hardcoded IE 10.0 Mobile user agent to resolve this issue. If there's a better way to set the User Agent of the HttpWebRequest it'll be nice.
